### PR TITLE
Fix the Synopsis

### DIFF
--- a/Test-RunValgrind/lib/Test/RunValgrind.pm
+++ b/Test-RunValgrind/lib/Test/RunValgrind.pm
@@ -143,14 +143,15 @@ Test::RunValgrind - tests that an external program is valgrind-clean.
 =head1 SYNOPSIS
 
     use Test::More tests => 1;
+    use Test::RunValgrind;
 
     # TEST
-    Test::RunValgrind->new({})->run(
+    Test::RunValgrind->new( {} )->run(
         {
             log_fn => './expr--valgrind-log.txt',
-            prog => '/usr/bin/expr',
-            argv => [qw/5 + 6/],
-            blurb => 'valgrind likes /usr/bin/expr',
+            prog   => '/usr/bin/expr',
+            argv   => [qw/5 + 6/],
+            blurb  => 'valgrind likes /usr/bin/expr',
         }
     );
 


### PR DESCRIPTION
Make the code tidy so it passes its own tests. Also, actually use the
module itself so that copy-pasted Synopsis works as is.

Maybe using $^X with -e1 would be more portable than expr?